### PR TITLE
Add reusable lesson utilities and automated tests

### DIFF
--- a/llm_course/__init__.py
+++ b/llm_course/__init__.py
@@ -1,0 +1,68 @@
+"""Convenience re-exports for the course notebooks."""
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Dict, Tuple
+
+_IMPORT_MAP: Dict[str, Tuple[str, str]] = {
+    # Lesson 1
+    "lesson1_aggregate_corpus": ("llm_course.lesson1", "aggregate_corpus"),
+    "lesson1_get_stats": ("llm_course.lesson1", "get_stats"),
+    "lesson1_get_vocab": ("llm_course.lesson1", "get_vocab"),
+    "lesson1_learn_bpe": ("llm_course.lesson1", "learn_bpe"),
+    "lesson1_merge_vocab": ("llm_course.lesson1", "merge_vocab"),
+    "lesson1_tokenize": ("llm_course.lesson1", "tokenize"),
+    # Lesson 2
+    "lesson2_prepare_tokens": ("llm_course.lesson2", "prepare_tokens"),
+    "lesson2_build_vocabulary": ("llm_course.lesson2", "build_vocabulary"),
+    "lesson2_build_cooccurrence": ("llm_course.lesson2", "build_cooccurrence"),
+    "lesson2_compute_embeddings": ("llm_course.lesson2", "compute_embeddings"),
+    "lesson2_cosine": ("llm_course.lesson2", "cosine"),
+    "lesson2_neighbors": ("llm_course.lesson2", "neighbors"),
+    # Lesson 3
+    "lesson3_ngrams": ("llm_course.lesson3", "ngrams"),
+    "lesson3_train_ngram": ("llm_course.lesson3", "train_ngram"),
+    "lesson3_sample": ("llm_course.lesson3", "sample"),
+    "lesson3_cross_entropy": ("llm_course.lesson3", "cross_entropy"),
+    # Lesson 4
+    "SelfAttention": ("llm_course.lesson4", "SelfAttention"),
+    "TinyTransformer": ("llm_course.lesson4", "TinyTransformer"),
+    "lesson4_encode": ("llm_course.lesson4", "encode"),
+    "lesson4_decode": ("llm_course.lesson4", "decode"),
+    # Lesson 5
+    "lesson5_aggregate_texts": ("llm_course.lesson5", "aggregate_texts"),
+    "lesson5_tokenize_texts": ("llm_course.lesson5", "tokenize_texts"),
+    # Lesson 6
+    "lesson6_FORBIDDEN": ("llm_course.lesson6", "FORBIDDEN"),
+    "lesson6_safe_input": ("llm_course.lesson6", "safe_input"),
+    "lesson6_train_bigram": ("llm_course.lesson6", "train_bigram"),
+    "lesson6_cross_entropy": ("llm_course.lesson6", "cross_entropy"),
+}
+
+__all__ = sorted(_IMPORT_MAP)
+
+
+def _load(name: str):
+    module_name, attr = _IMPORT_MAP[name]
+    try:
+        module: ModuleType = import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional deps
+        if module_name.endswith("lesson4") and exc.name == "torch":
+            raise ModuleNotFoundError(
+                "PyTorch is required to use Lesson 4 utilities"
+            ) from exc
+        raise
+    value = getattr(module, attr)
+    globals()[name] = value
+    return value
+
+
+def __getattr__(name: str):  # pragma: no cover - simple attribute hook
+    if name in _IMPORT_MAP:
+        return _load(name)
+    raise AttributeError(name)
+
+
+def __dir__():  # pragma: no cover - debugging helper
+    return sorted(list(globals()) + list(_IMPORT_MAP))

--- a/llm_course/lesson1.py
+++ b/llm_course/lesson1.py
@@ -1,0 +1,99 @@
+"""Utilities mirroring Lesson 1 (Tokens & Tokenizers)."""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+CorpusFiles = Sequence[str]
+Merge = Tuple[str, str]
+
+
+def aggregate_corpus(
+    data_dir: Path | str,
+    corpus_files: CorpusFiles,
+    encoding: str = "utf-8",
+) -> str:
+    """Return concatenated text for the requested files.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory that contains the text files.
+    corpus_files:
+        Iterable of file names to concatenate.
+    encoding:
+        File encoding used when reading the corpus.
+    """
+    base = Path(data_dir)
+    texts: List[str] = []
+    for name in corpus_files:
+        path = base / name
+        texts.append(path.read_text(encoding=encoding))
+    return "\n".join(texts)
+
+
+def get_vocab(text: str) -> Counter[str]:
+    """Return the character-level vocabulary with ``</w>`` markers."""
+    words = re.findall(r"\S+", text.lower())
+    return Counter(" ".join(list(word)) + " </w>" for word in words)
+
+
+def get_stats(vocab: Counter[str]) -> Counter[Merge]:
+    """Count symbol pair frequencies for the current vocabulary."""
+    pairs: Counter[Merge] = Counter()
+    for word, freq in vocab.items():
+        symbols = word.split()
+        for i in range(len(symbols) - 1):
+            pairs[(symbols[i], symbols[i + 1])] += freq
+    return pairs
+
+
+def merge_vocab(pair: Merge, vocab_in: Counter[str]) -> Counter[str]:
+    """Merge the given ``pair`` inside ``vocab_in`` and return an updated copy."""
+    merged = Counter()
+    bigram = " ".join(pair)
+    replacement = "".join(pair)
+    for word, freq in vocab_in.items():
+        merged[word.replace(bigram, replacement)] += freq
+    return merged
+
+
+def learn_bpe(text: str, num_merges: int) -> List[Merge]:
+    """Learn a list of BPE merges for ``text``."""
+    vocab = get_vocab(text)
+    merges: List[Merge] = []
+    for _ in range(num_merges):
+        pairs = get_stats(vocab)
+        if not pairs:
+            break
+        best = max(pairs, key=pairs.get)
+        merges.append(best)
+        vocab = merge_vocab(best, vocab)
+    return merges
+
+
+def tokenize(word: str, merges: Iterable[Merge]) -> List[str]:
+    """Tokenise ``word`` according to ``merges`` learned by ``learn_bpe``."""
+    symbols: List[str] = list(word.lower()) + ["</w>"]
+    for a, b in merges:
+        i = 0
+        while i < len(symbols) - 1:
+            if symbols[i] == a and symbols[i + 1] == b:
+                symbols[i : i + 2] = [a + b]
+            else:
+                i += 1
+    if symbols and symbols[-1] == "</w>":
+        symbols = symbols[:-1]
+    return symbols
+
+
+__all__ = [
+    "aggregate_corpus",
+    "get_vocab",
+    "get_stats",
+    "merge_vocab",
+    "learn_bpe",
+    "tokenize",
+]

--- a/llm_course/lesson2.py
+++ b/llm_course/lesson2.py
@@ -1,0 +1,88 @@
+"""Utilities for Lesson 2 (Embeddings & Similarity)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import numpy as np
+
+
+@dataclass
+class Vocabulary:
+    words: Sequence[str]
+    word_to_index: Dict[str, int]
+    index_to_word: Dict[int, str]
+
+
+def prepare_tokens(text: str) -> List[str]:
+    """Lower-case ``text`` and return alphanumeric tokens."""
+    return re.findall(r"[a-zA-Z']+", text.lower())
+
+
+def build_vocabulary(tokens: Iterable[str]) -> Vocabulary:
+    words = sorted(set(tokens))
+    word_to_index = {w: i for i, w in enumerate(words)}
+    index_to_word = {i: w for w, i in word_to_index.items()}
+    return Vocabulary(words, word_to_index, index_to_word)
+
+
+def build_cooccurrence(tokens: Sequence[str], vocab: Vocabulary, window: int = 2) -> np.ndarray:
+    """Build a symmetric co-occurrence matrix."""
+    V = len(vocab.words)
+    matrix = np.zeros((V, V), dtype=np.float32)
+    for i, token in enumerate(tokens):
+        wi = vocab.word_to_index[token]
+        left = max(0, i - window)
+        right = min(len(tokens), i + window + 1)
+        for j in range(left, right):
+            if j == i:
+                continue
+            wj = vocab.word_to_index[tokens[j]]
+            matrix[wi, wj] += 1.0
+    return matrix
+
+
+def compute_embeddings(cooccurrence: np.ndarray, dims: int = 16) -> np.ndarray:
+    """Return truncated SVD embeddings just like in the notebook."""
+    U, S, _ = np.linalg.svd(cooccurrence + 1e-6, full_matrices=False)
+    dims = min(dims, U.shape[1])
+    return U[:, :dims] * S[:dims]
+
+
+def cosine(a: np.ndarray, b: np.ndarray) -> float:
+    """Return cosine similarity between two vectors."""
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+    if denom == 0:
+        return 0.0
+    return float(np.dot(a, b) / (denom + 1e-9))
+
+
+def neighbors(
+    query: str,
+    embeddings: np.ndarray,
+    vocab: Vocabulary,
+    k: int = 8,
+) -> List[Tuple[float, str]]:
+    """Return the ``k`` nearest neighbours of ``query`` using cosine similarity."""
+    if query not in vocab.word_to_index:
+        return []
+    qi = vocab.word_to_index[query]
+    sims: List[Tuple[float, str]] = []
+    for i in range(len(vocab.words)):
+        if i == qi:
+            continue
+        sims.append((cosine(embeddings[qi], embeddings[i]), vocab.index_to_word[i]))
+    sims.sort(key=lambda item: item[0], reverse=True)
+    return sims[:k]
+
+
+__all__ = [
+    "Vocabulary",
+    "prepare_tokens",
+    "build_vocabulary",
+    "build_cooccurrence",
+    "compute_embeddings",
+    "cosine",
+    "neighbors",
+]

--- a/llm_course/lesson3.py
+++ b/llm_course/lesson3.py
@@ -1,0 +1,104 @@
+"""Utilities for Lesson 3 (N-gram language models)."""
+from __future__ import annotations
+
+import collections
+import math
+import random
+from typing import Callable, Iterable, Iterator, List, Sequence, Tuple
+
+Token = str
+NGram = Tuple[Token, ...]
+ProbabilityFn = Callable[[NGram, Token], float]
+
+
+def ngrams(tokens: Sequence[Token], n: int) -> Iterator[NGram]:
+    """Yield ``n``-grams from ``tokens``."""
+    if n <= 0:
+        raise ValueError("n must be positive")
+    for i in range(len(tokens) - n + 1):
+        yield tuple(tokens[i : i + n])
+
+
+def train_ngram(tokens: Sequence[Token], n: int = 2, k: float = 1.0) -> Tuple[ProbabilityFn, List[Token]]:
+    """Train a Laplace-smoothed ``n``-gram model."""
+    if n < 1:
+        raise ValueError("n must be >= 1")
+    counts = collections.Counter(ngrams(tokens, n))
+    ctx_counts = collections.Counter(ngrams(tokens, n - 1)) if n > 1 else None
+    vocab = sorted(set(tokens))
+    V = len(vocab)
+
+    def prob(context: NGram, word: Token) -> float:
+        if n == 1:
+            total = len(tokens)
+            return (counts[(word,)] + k) / (total + k * V)
+        ctx = ctx_counts[context]
+        return (counts[context + (word,)] + k) / (ctx + k * V)
+
+    return prob, vocab
+
+
+def sample(
+    prob: ProbabilityFn,
+    vocab: Sequence[Token],
+    n: int = 2,
+    max_len: int = 30,
+    temperature: float = 1.0,
+    seed: int | None = None,
+) -> List[Token]:
+    """Sample a sequence from an ``n``-gram model."""
+    random.seed(seed)
+    if n == 1:
+        context: List[Token] = []
+    elif n == 2:
+        context = [random.choice(vocab)]
+    else:
+        context = [random.choice(vocab), random.choice(vocab)]
+
+    result: List[Token] = []
+    for _ in range(max_len):
+        scores = [prob(tuple(context[-(n - 1):]), w) ** (1.0 / temperature) for w in vocab]
+        total = sum(scores)
+        r = random.random() * total
+        cum = 0.0
+        chosen = vocab[0]
+        for w, score in zip(vocab, scores):
+            cum += score
+            if cum >= r:
+                chosen = w
+                break
+        result.append(chosen)
+        if n == 1:
+            context = []
+        else:
+            context = (context + [chosen])[-(n - 1):]
+    return result
+
+
+def cross_entropy(
+    prob: ProbabilityFn,
+    tokens: Sequence[Token],
+    n: int,
+    split: float = 0.8,
+) -> float:
+    """Return the cross-entropy on the held-out set."""
+    if not 0 < split < 1:
+        raise ValueError("split must be between 0 and 1")
+    pivot = int(len(tokens) * split)
+    test = tokens[pivot:]
+    if n == 1:
+        contexts = [() for _ in test]
+    else:
+        contexts = [tuple(test[max(0, i - (n - 1)) : i]) for i in range(len(test))]
+    H = 0.0
+    count = 0
+    for ctx, word in zip(contexts, test):
+        if len(ctx) != n - 1:
+            continue
+        p = max(prob(ctx, word), 1e-12)
+        H += -math.log2(p)
+        count += 1
+    return H / max(count, 1)
+
+
+__all__ = ["ngrams", "train_ngram", "sample", "cross_entropy"]

--- a/llm_course/lesson4.py
+++ b/llm_course/lesson4.py
@@ -1,0 +1,126 @@
+"""Utilities for Lesson 4 (Tiny Transformer)."""
+from __future__ import annotations
+
+import math
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+
+class SelfAttention(nn.Module):
+    """Multi-head self-attention with a causal mask."""
+
+    def __init__(self, n_embd: int, n_head: int) -> None:
+        super().__init__()
+        if n_embd % n_head != 0:
+            raise ValueError("n_embd must be divisible by n_head")
+        self.n_head = n_head
+        self.head_dim = n_embd // n_head
+        self.qkv = nn.Linear(n_embd, 3 * n_embd, bias=False)
+        self.proj = nn.Linear(n_embd, n_embd, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, C = x.shape
+        qkv = self.qkv(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+        q = q.view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        k = k.view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        v = v.view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        att = (q @ k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+        mask = torch.tril(torch.ones(T, T, device=x.device, dtype=torch.bool))
+        att = att.masked_fill(~mask, float("-inf"))
+        att = torch.softmax(att, dim=-1)
+        out = att @ v
+        out = out.transpose(1, 2).contiguous().view(B, T, C)
+        return self.proj(out)
+
+
+class Block(nn.Module):
+    """Transformer block used by :class:`TinyTransformer`."""
+
+    def __init__(self, n_embd: int, n_head: int, dropout: float = 0.0) -> None:
+        super().__init__()
+        self.ln1 = nn.LayerNorm(n_embd)
+        self.sa = SelfAttention(n_embd, n_head)
+        self.ln2 = nn.LayerNorm(n_embd)
+        self.ff = nn.Sequential(
+            nn.Linear(n_embd, 4 * n_embd),
+            nn.GELU(),
+            nn.Linear(4 * n_embd, n_embd),
+        )
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.drop(self.sa(self.ln1(x)))
+        x = x + self.drop(self.ff(self.ln2(x)))
+        return x
+
+
+class TinyTransformer(nn.Module):
+    """A very small GPT-style Transformer used throughout the lessons."""
+
+    def __init__(
+        self,
+        vocab_size: int,
+        n_embd: int = 128,
+        n_head: int = 4,
+        n_layer: int = 2,
+        block_size: int = 64,
+    ) -> None:
+        super().__init__()
+        self.token_emb = nn.Embedding(vocab_size, n_embd)
+        self.pos_emb = nn.Embedding(block_size, n_embd)
+        self.blocks = nn.Sequential(*[Block(n_embd, n_head) for _ in range(n_layer)])
+        self.ln = nn.LayerNorm(n_embd)
+        self.head = nn.Linear(n_embd, vocab_size)
+        self.block_size = block_size
+
+    def forward(self, idx: torch.Tensor, targets: torch.Tensor | None = None):
+        B, T = idx.shape
+        if T > self.block_size:
+            raise ValueError("Sequence length exceeds block size")
+        tok = self.token_emb(idx)
+        pos = self.pos_emb(torch.arange(T, device=idx.device))
+        x = tok + pos
+        x = self.blocks(x)
+        x = self.ln(x)
+        logits = self.head(x)
+        loss = None
+        if targets is not None:
+            loss = nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return logits, loss
+
+    @torch.no_grad()
+    def generate(self, idx: torch.Tensor, max_new_tokens: int = 100) -> torch.Tensor:
+        for _ in range(max_new_tokens):
+            idx_cond = idx[:, -self.block_size :]
+            logits, _ = self(idx_cond)
+            logits = logits[:, -1, :]
+            probs = torch.softmax(logits, dim=-1)
+            next_id = torch.multinomial(probs, num_samples=1)
+            idx = torch.cat([idx, next_id], dim=1)
+        return idx
+
+
+def build_vocab(text: str) -> Dict[str, int]:
+    chars = sorted(set(text))
+    return {ch: i for i, ch in enumerate(chars)}
+
+
+def encode(text: str, stoi: Dict[str, int]) -> torch.Tensor:
+    return torch.tensor([stoi[c] for c in text], dtype=torch.long)
+
+
+def decode(tensor: torch.Tensor, itos: Dict[int, str]) -> str:
+    return "".join(itos[int(i)] for i in tensor)
+
+
+__all__ = [
+    "SelfAttention",
+    "Block",
+    "TinyTransformer",
+    "build_vocab",
+    "encode",
+    "decode",
+]

--- a/llm_course/lesson5.py
+++ b/llm_course/lesson5.py
@@ -1,0 +1,43 @@
+"""Utilities for Lesson 5 (Fine-tuning with Hugging Face)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Protocol
+
+
+@dataclass
+class CorpusConfig:
+    data_dir: Path
+    corpus_files: Iterable[str]
+
+
+def aggregate_texts(config: CorpusConfig, encoding: str = "utf-8") -> str:
+    """Concatenate multiple corpus files just like in the notebook."""
+    texts: List[str] = []
+    for name in config.corpus_files:
+        path = config.data_dir / name
+        texts.append(path.read_text(encoding=encoding))
+    return "\n".join(texts)
+
+
+class SupportsTokenize(Protocol):
+    def __call__(self, text: str, *, truncation: bool, max_length: int) -> dict:
+        ...
+
+
+def tokenize_texts(
+    tokenizer: SupportsTokenize,
+    texts: Iterable[str],
+    *,
+    truncation: bool = True,
+    max_length: int = 512,
+) -> List[dict]:
+    """Tokenise ``texts`` with a ``tokenizer`` that mimics the notebook behaviour."""
+    batches = []
+    for text in texts:
+        batches.append(tokenizer(text, truncation=truncation, max_length=max_length))
+    return batches
+
+
+__all__ = ["CorpusConfig", "aggregate_texts", "tokenize_texts", "SupportsTokenize"]

--- a/llm_course/lesson6.py
+++ b/llm_course/lesson6.py
@@ -1,0 +1,56 @@
+"""Utilities for Lesson 6 (Evaluation, Prompting, Safety)."""
+from __future__ import annotations
+
+import collections
+import math
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+Token = str
+BigramProb = Tuple[str, str]
+FORBIDDEN = [
+    r"how to make a bomb",
+    r"credit card number",
+    r"social security number",
+]
+
+
+def ngrams(tokens: Sequence[Token], n: int) -> Iterable[Tuple[Token, ...]]:
+    for i in range(len(tokens) - n + 1):
+        yield tuple(tokens[i : i + n])
+
+
+def train_bigram(tokens: Sequence[Token], k: float = 0.5):
+    counts = collections.Counter(ngrams(tokens, 2))
+    ctx_counts = collections.Counter(ngrams(tokens, 1))
+    vocab = sorted(set(tokens))
+    V = len(vocab)
+
+    def prob(prev: Token, nxt: Token) -> float:
+        return (counts[(prev, nxt)] + k) / (ctx_counts[(prev,)] + k * V)
+
+    return prob, vocab
+
+
+def cross_entropy(prob, tokens: Sequence[Token]) -> Tuple[float, float]:
+    split = int(0.8 * len(tokens))
+    test = tokens[split:]
+    H = 0.0
+    count = 0
+    for i in range(1, len(test)):
+        p = max(prob(test[i - 1], test[i]), 1e-12)
+        H += -math.log2(p)
+        count += 1
+    H = H / max(count, 1)
+    return H, 2 ** H
+
+
+def safe_input(user_text: str) -> Tuple[bool, str]:
+    t = user_text.lower()
+    for pattern in FORBIDDEN:
+        if re.search(pattern, t):
+            return False, f"Blocked by rule: {pattern}"
+    return True, "ok"
+
+
+__all__ = ["FORBIDDEN", "ngrams", "train_bigram", "cross_entropy", "safe_input"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,12 @@ dependencies = [
     "transformers"
 ]
 
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["llm_course*"]
+
 [tool.uv]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,14 @@
+import importlib
+import subprocess
+import sys
+
+
+def test_project_is_installable(tmp_path):
+    target = tmp_path / "site"
+    target.mkdir()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", ".", "--target", str(target), "--no-deps"],
+    )
+    sys.path.insert(0, str(target))
+    module = importlib.import_module("llm_course")
+    assert hasattr(module, "lesson1_get_vocab")

--- a/tests/test_lesson1.py
+++ b/tests/test_lesson1.py
@@ -1,0 +1,38 @@
+import collections
+from pathlib import Path
+
+from llm_course.lesson1 import (
+    aggregate_corpus,
+    get_stats,
+    get_vocab,
+    learn_bpe,
+    merge_vocab,
+    tokenize,
+)
+
+
+def test_aggregate_corpus(tmp_path: Path):
+    file1 = tmp_path / "a.txt"
+    file2 = tmp_path / "b.txt"
+    file1.write_text("hello")
+    file2.write_text("world")
+    text = aggregate_corpus(tmp_path, ["a.txt", "b.txt"])
+    assert "hello" in text and "world" in text
+
+
+def test_get_stats_counts_pairs():
+    vocab = collections.Counter({"l o w </w>": 2, "l o w e r </w>": 1})
+    stats = get_stats(vocab)
+    assert stats[("l", "o")] == 3
+    assert stats[("o", "w")] == 3
+
+
+def test_merge_and_tokenize_roundtrip():
+    text = "low lower lowest"
+    merges = learn_bpe(text, 10)
+    assert merges[0] == ("l", "o")
+    vocab = get_vocab(text)
+    merged_vocab = merge_vocab(merges[0], vocab)
+    assert any(token.startswith("lo") for token in merged_vocab)
+    assert tokenize("lower", merges) == ["lower</w>"]
+    assert tokenize("lowest", merges) == ["lowest</w>"]

--- a/tests/test_lesson2.py
+++ b/tests/test_lesson2.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from llm_course.lesson2 import (
+    Vocabulary,
+    build_cooccurrence,
+    build_vocabulary,
+    compute_embeddings,
+    cosine,
+    neighbors,
+    prepare_tokens,
+)
+
+
+def test_prepare_tokens_and_vocab():
+    tokens = prepare_tokens("Dogs chase cats!")
+    assert tokens == ["dogs", "chase", "cats"]
+    vocab = build_vocabulary(tokens)
+    assert isinstance(vocab, Vocabulary)
+    assert vocab.word_to_index["cats"] >= 0
+
+
+def test_cooccurrence_window_counts():
+    tokens = ["dog", "likes", "cat", "likes", "dog"]
+    vocab = build_vocabulary(tokens)
+    matrix = build_cooccurrence(tokens, vocab, window=1)
+    dog_index = vocab.word_to_index["dog"]
+    likes_index = vocab.word_to_index["likes"]
+    assert matrix[dog_index, likes_index] == pytest.approx(2.0)
+    assert matrix[likes_index, dog_index] == pytest.approx(2.0)
+
+
+def test_embeddings_and_neighbors():
+    tokens = ["dog", "runs", "fast", "dog", "chases", "cat"]
+    vocab = build_vocabulary(tokens)
+    cooc = build_cooccurrence(tokens, vocab, window=2)
+    emb = compute_embeddings(cooc, dims=3)
+    assert emb.shape[1] == 3
+    # construct manual embeddings for deterministic neighbours
+    manual = np.array(
+        [
+            [0.0, 0.8, 0.2],  # cat
+            [0.1, 0.1, 0.9],  # chases
+            [0.0, 1.0, 0.0],  # dog
+            [0.0, 0.9, 0.1],  # fast
+            [1.0, 0.0, 0.0],  # runs
+        ]
+    )
+    vocab_manual = Vocabulary(
+        words=["cat", "chases", "dog", "fast", "runs"],
+        word_to_index={w: i for i, w in enumerate(["cat", "chases", "dog", "fast", "runs"])},
+        index_to_word={i: w for i, w in enumerate(["cat", "chases", "dog", "fast", "runs"])},
+    )
+    neigh = neighbors("dog", manual, vocab_manual, k=2)
+    assert neigh[0][1] == "fast"
+    assert neigh[1][1] == "cat"
+    assert neighbors("unknown", manual, vocab_manual) == []
+
+
+def test_cosine_similarity_properties():
+    a = np.array([1.0, 0.0])
+    b = np.array([1.0, 0.0])
+    c = np.array([0.0, 1.0])
+    assert cosine(a, b) == pytest.approx(1.0)
+    assert cosine(a, c) == pytest.approx(0.0, abs=1e-6)

--- a/tests/test_lesson3.py
+++ b/tests/test_lesson3.py
@@ -1,0 +1,37 @@
+import math
+
+import pytest
+
+from llm_course.lesson3 import cross_entropy, ngrams, sample, train_ngram
+
+
+def test_ngrams_generation():
+    tokens = ["a", "b", "c", "d"]
+    assert list(ngrams(tokens, 2)) == [("a", "b"), ("b", "c"), ("c", "d")]
+    with pytest.raises(ValueError):
+        list(ngrams(tokens, 0))
+
+
+def test_train_ngram_probability():
+    tokens = ["hello", "world", "hello", "planet"]
+    prob, vocab = train_ngram(tokens, n=2, k=1.0)
+    assert set(vocab) == {"hello", "world", "planet"}
+    p = prob(("hello",), "world")
+    assert 0.0 < p < 1.0
+
+
+def test_sample_returns_tokens():
+    tokens = ["hi", "there", "hi", "friend"]
+    prob, vocab = train_ngram(tokens, n=2, k=1.0)
+    out = sample(prob, vocab, n=2, max_len=5, seed=0)
+    assert len(out) == 5
+    assert set(out).issubset(set(vocab))
+
+
+def test_cross_entropy_reasonable():
+    tokens = ["a", "b", "a", "b", "a", "b", "a", "b"]
+    prob, _ = train_ngram(tokens, n=2, k=0.5)
+    H = cross_entropy(prob, tokens, n=2, split=0.5)
+    assert H >= 0
+    with pytest.raises(ValueError):
+        cross_entropy(prob, tokens, n=2, split=1.5)

--- a/tests/test_lesson4.py
+++ b/tests/test_lesson4.py
@@ -1,0 +1,44 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from llm_course.lesson4 import SelfAttention, TinyTransformer, decode, encode
+
+
+def _set_identity_weights(attn: SelfAttention) -> None:
+    with torch.no_grad():
+        attn.qkv.weight.zero_()
+        hidden = attn.qkv.weight.shape[1]
+        attn.qkv.weight[:hidden, :] = torch.eye(hidden)
+        attn.qkv.weight[hidden : 2 * hidden, :] = torch.eye(hidden)
+        attn.qkv.weight[2 * hidden :, :] = torch.eye(hidden)
+        attn.proj.weight.copy_(torch.eye(hidden))
+
+
+def test_self_attention_is_causal():
+    attn = SelfAttention(n_embd=2, n_head=1)
+    _set_identity_weights(attn)
+    x = torch.tensor([[[1.0, 0.0], [0.0, 5.0]]])
+    out = attn(x)
+    first_token = out[0, 0]
+    assert torch.allclose(first_token, torch.tensor([1.0, 0.0]), atol=1e-5)
+
+
+def test_tiny_transformer_forward_and_generate():
+    vocab_size = 5
+    model = TinyTransformer(vocab_size=vocab_size, n_embd=8, n_head=2, n_layer=1, block_size=4)
+    x = torch.zeros((2, 4), dtype=torch.long)
+    logits, loss = model(x, x)
+    assert logits.shape == (2, 4, vocab_size)
+    assert loss is not None
+    context = torch.zeros((1, 1), dtype=torch.long)
+    generated = model.generate(context, max_new_tokens=3)
+    assert generated.shape == (1, 4)
+
+
+def test_encode_decode_roundtrip():
+    stoi = {"a": 0, "b": 1}
+    itos = {0: "a", 1: "b"}
+    ids = encode("abba", stoi)
+    assert ids.tolist() == [0, 1, 1, 0]
+    assert decode(ids, itos) == "abba"

--- a/tests/test_lesson5.py
+++ b/tests/test_lesson5.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from llm_course.lesson5 import CorpusConfig, aggregate_texts, tokenize_texts
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, text: str, *, truncation: bool, max_length: int) -> dict:
+        self.calls.append((text, truncation, max_length))
+        return {"length": min(len(text), max_length)}
+
+
+def test_aggregate_texts(tmp_path: Path):
+    files = ["one.txt", "two.txt"]
+    for name, content in zip(files, ["hello", "world"]):
+        (tmp_path / name).write_text(content)
+    config = CorpusConfig(data_dir=tmp_path, corpus_files=files)
+    combined = aggregate_texts(config)
+    assert "hello" in combined and "world" in combined
+
+
+def test_tokenize_texts_calls_tokenizer():
+    tokenizer = DummyTokenizer()
+    outputs = tokenize_texts(tokenizer, ["abc", "defg"], max_length=5)
+    assert tokenizer.calls[0] == ("abc", True, 5)
+    assert outputs == [{"length": 3}, {"length": 4}]

--- a/tests/test_lesson6.py
+++ b/tests/test_lesson6.py
@@ -1,0 +1,19 @@
+from llm_course.lesson6 import FORBIDDEN, cross_entropy, safe_input, train_bigram
+
+
+def test_bigram_training_and_cross_entropy():
+    tokens = ["a", "b", "a", "b", "a", "b"]
+    prob, vocab = train_bigram(tokens, k=0.5)
+    assert set(vocab) == {"a", "b"}
+    H, ppl = cross_entropy(prob, tokens)
+    assert H >= 0
+    assert ppl >= 1
+
+
+def test_safe_input_blocks_forbidden_phrases():
+    ok, msg = safe_input("Tell me a happy story about space explorers")
+    assert ok and msg == "ok"
+    blocked_phrase = FORBIDDEN[0]
+    ok, msg = safe_input(f"Please explain {blocked_phrase}")
+    assert not ok
+    assert blocked_phrase in msg


### PR DESCRIPTION
## Summary
- add a reusable `llm_course` package with helper modules that mirror the logic from Lessons 1 through 6
- expose lazy re-exports so downstream users can import lesson utilities without requiring all optional dependencies
- configure packaging metadata and add pytest suites that validate every lesson workflow plus a smoke test for `pip install .`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d493396438832dab2ee3736b4e4dcf