### PR TITLE
Expand lesson slide notes with detailed activities

### DIFF
--- a/slides/L1_Tokens_and_Tokenizers.md
+++ b/slides/L1_Tokens_and_Tokenizers.md
@@ -1,5 +1,63 @@
-# L1 Tokens and Tokenizers
+# L1 Tokens and Tokenizers — Extended Lesson Notes
 
-- Goal: Understand bytes → tokens → BPE merges
-- Hands-on: Build a tiny BPE tokenizer; edit corpus and re-train merges
-- Key concept: subword tokens compress frequent patterns
+## Lesson Flow at a Glance
+- **Spark curiosity (10 min):** Students manually tokenize a mini sentence with scissors and paper slips to feel what "breaking text into pieces" means.
+- **Guided discovery (25 min):** Walk through the notebook sections on character vocabularies, pair counts, and merge rules, pausing for think-pair-share questions.
+- **Hands-on build (30 min):** Learners implement and run the tiny BPE tokenizer, experimenting with different corpora from the `data/` folder.
+- **Reflection + challenge (15 min):** Compare tokenizations from different corpora, journal observations, and plan extension experiments.
+
+> **Reminder:** These notes expand on the notebook. Use them to enrich discussion, add unplugged activities, and surface connections the code doesn’t show explicitly.
+
+## Warm-Up: Tokenizing by Hand
+1. Write the sentence "Friendly robots help humans" on the board.
+2. Hand each student index cards printed with single characters (including the space character and a `</w>` marker).
+3. Challenge small groups to arrange the cards into words, then into frequent character pairs they notice. Ask:
+   - Which pairs show up more than once?
+   - Would combining those pairs make writing the sentence faster next time?
+4. Introduce the vocabulary formally:
+   - **Token:** A chunk of text the computer treats as a single unit.
+   - **Corpus:** The training collection whose patterns decide which tokens are useful.
+   - **Merge rule:** An instruction like "if you see `ro` followed by `bot`, glue them together." Write one merge on the board.
+
+## Deep Dive: Why BPE Works
+Connect the warm-up to the algorithm from the notebook.
+- **Compression intuition:** Frequent pairs shrink the total number of symbols. Use a table showing how a 4-word corpus loses characters as merges happen.
+- **Frequency spotting:** Show a short corpus and circle all occurrences of the pair `th`. Count them aloud to model the tallying step before the code does it.
+- **Balancing act:** Explain that BPE keeps rare words in smaller pieces so the tokenizer can handle surprises. Relate to Lego sets: common bricks stay whole, custom shapes are built from standard pieces.
+
+### Pen-and-Paper Practice
+Give students a two-sentence corpus such as:
+```
+space ships sparkle
+space suits sparkle
+```
+Have them:
+1. Append `</w>` to each word.
+2. Count pair frequencies manually (use tally marks in a table).
+3. Decide the first two merges.
+4. Apply the merges to the corpus and write the new tokenized form.
+Discuss how the vocabulary shifts—"space" becomes a single token, while "sparkle" remains split after only two merges.
+
+## Guided Notebook Walkthrough
+As you move through the code cells, emphasize the conceptual checkpoints.
+1. **Character split + `</w>` (Step 1):** Ask learners why we need an end-of-word marker. Highlight how it prevents merges across spaces.
+2. **Pair counting (Step 2):** Encourage students to print the top 10 pairs. Prompt them to predict the next merge before revealing it.
+3. **Merge application (Step 3):** Relate the iterative loop to building a dictionary. Each loop adds a new "shortcut" symbol.
+4. **Tokenizing new sentences:** Demonstrate with both an in-corpus sentence and a novel one (e.g., "Robots explore space"). Compare token counts before/after merges.
+
+## Stretch the Experiment
+Suggest optional branching paths once the core notebook runs:
+- **Corpus Remix:** Split the class—half edits `space.txt`, half edits `animals.txt`. After retraining, swap tokenizers and tokenize the same test sentence. Chart differences on the board.
+- **Merge Budget Game:** Set merge counts (10, 50, 200) and have teams argue which number gives the best trade-off between vocabulary size and token length. Use evidence from their token counts.
+- **Visual Timeline:** Ask students to plot merge number vs. token count reduction on graph paper. Discuss where the curve flattens.
+
+## Reflection Prompts
+Encourage individual or pair reflections:
+- How did changing the corpus alter which merges were learned first? Why?
+- Which merge surprised you the most? What does it reveal about the text’s patterns?
+- If you wanted the tokenizer to understand fantasy spell names, what data would you add?
+
+## Exit Ticket Ideas
+- **Quick quiz:** Provide three candidate merges and ask which would appear next given a frequency table.
+- **Analogy sketch:** Students draw a metaphor (puzzle pieces, cooking recipe, etc.) to explain BPE to a younger sibling.
+- **Plan ahead:** Write one hypothesis about how a Minecraft-heavy corpus will tokenize "redstone" before running the experiment next lesson.

--- a/slides/L2_Embeddings_and_Similarity.md
+++ b/slides/L2_Embeddings_and_Similarity.md
@@ -1,5 +1,65 @@
-# L2 Embeddings and Similarity
+# L2 Embeddings and Similarity — Extended Lesson Notes
 
-- Goal: From one-hot to dense vectors; co-occurrence → SVD
-- Hands-on: Build word co-occurrence, compute SVD, 2D plot, cosine neighbors
-- Key concept: semantic similarity emerges from usage patterns
+## Lesson Flow at a Glance
+- **Concept ignition (10 min):** Use a word-web on the board to illustrate semantic neighborhoods.
+- **Data craft (20 min):** Construct a co-occurrence matrix by hand for a tiny corpus, then mirror the process in the notebook.
+- **Linear algebra adventure (25 min):** Walk through SVD intuition with paper folding and axis metaphors before running the code.
+- **Exploration lab (25 min):** Students probe nearest neighbors, tweak hyperparameters, and journal discoveries.
+
+## Warm-Up: Semantic Neighborhood Walk
+1. Write "astronaut" in the center of a large sheet. Ask students to suggest related words; cluster them (spacecraft, NASA, gravity).
+2. Discuss what makes a word feel "close"—shared stories? Same categories? Similar verbs?
+3. Introduce embeddings as the computer's way to place words in a **vector space** so closeness can be measured numerically.
+4. Vocabulary spotlight:
+   - **Embedding:** A numeric vector representing a word's relationships.
+   - **Co-occurrence window:** The number of neighboring words we care about on each side.
+   - **Cosine similarity:** Measures how aligned two vectors are; 1.0 means pointing the same direction.
+
+## Building Co-Occurrence Intuition (Pen & Paper)
+Provide the mini corpus:
+```
+rockets launch fast
+astronauts fly rockets
+```
+1. List the unique words (include `<PAD>` or `<UNK>` if you plan to in code).
+2. Choose a window size of 1. Draw a table with center words as rows and neighbor words as columns.
+3. Slide the window manually through each sentence. For "rockets launch fast" record that "rockets" sees "launch" once.
+4. Sum counts and fill the table.
+5. Ask students to circle which pairs got the highest counts. Predict which vectors will be similar.
+
+## Transition to Notebook Implementation
+- Highlight how the code generalizes the hand process: loops replace the sliding window you just simulated.
+- Encourage learners to compare their manual table to the printed matrix from the notebook. Are the numbers aligned? If not, debug together—perhaps a boundary case was missed.
+
+## SVD Without Fear
+Before running `scipy.sparse.linalg.svds`, ground the idea:
+- **Paper axis demo:** Hold two colored pencils as perpendicular axes. Place sticky notes representing words. Explain how SVD finds a new pair of axes that better align with the true themes (e.g., "space" vs. "speed").
+- **Energy metaphor:** The first singular value captures the loudest pattern. Ask what pattern that might be in the rocket corpus (probably "space terms vs. action verbs").
+- **Dimensionality choice:** Explain why we keep only the top *k* components—the rest contribute less meaning and add noise.
+
+### Optional Mathematical Dig
+For interested students:
+- Show the equation `M ≈ U_k Σ_k V_kᵀ` and map each piece to code variables.
+- Demonstrate how dividing by the square root of counts or applying Positive Pointwise Mutual Information (PPMI) changes the emphasis.
+
+## Exploring Embedding Space
+Use the notebook’s plotting and similarity helpers as jumping-off points.
+1. **Nearest neighbors:** Pick a word like "rocket" and compute top-5 neighbors. Ask students to justify each neighbor using sentences from the corpus.
+2. **Least similar words:** Identify vectors with cosine near zero or negative. Discuss what it means for meaning—do those words ever meet in the stories?
+3. **Two-corpus comparison:** Train once on `space.txt` and once on `animals.txt`. Plot both embeddings on graph paper using two axes (Dimension 1 vs. Dimension 2) and label points by hand. Are the clusters different?
+
+## Pen-and-Paper Challenge Stations
+Set up stations with printed co-occurrence tables and partially completed embeddings.
+- **Station A (Window sweep):** Students recalc counts with window size 2 and predict how "astronaut"’s vector changes.
+- **Station B (Analogies):** Provide three word vectors (numbers small enough for mental math). Have students compute cosine similarity with calculators and decide which word completes an analogy like "planet is to orbit as fish is to ____".
+- **Station C (Dimensional intuition):** Give a 2D scatter plot and ask students to annotate quadrants (e.g., top-right = "space nouns").
+
+## Reflection and Discussion
+- How does the choice of corpus shape what the embeddings "believe" about words?
+- What might happen if we train on social media slang—would "lit" move closer to "exciting" or "illumination"?
+- When could cosine similarity fail? Brainstorm cases where two words share neighbors but have opposite sentiment.
+
+## Extension Ideas
+- **Story blender:** Merge two themed corpora and observe whether SVD axes separate the themes. Encourage sketches of the axes with explanatory captions.
+- **Time capsule:** Add new sentences to the corpus each day and plot how a word’s neighbors shift. Keep a logbook of the drift.
+- **Explain to a friend:** Have students write a postcard explaining embeddings without using the word "vector." This reinforces conceptual clarity.

--- a/slides/L3_Ngram_Language_Models.md
+++ b/slides/L3_Ngram_Language_Models.md
@@ -1,5 +1,66 @@
-# L3 Ngram Language Models
+# L3 N-gram Language Models — Extended Lesson Notes
 
-- Goal: Next-token prediction with counts and smoothing
-- Hands-on: train 1/2/3-gram LMs; sample text; compute cross-entropy
-- Key concept: language modeling is probability over sequences
+## Lesson Flow at a Glance
+- **Prediction warm-up (10 min):** Students play a cloze game guessing the next word in famous phrases.
+- **Counting workshop (25 min):** Build unigram, bigram, and trigram tables on paper, then mirror the logic in code.
+- **Probability playground (25 min):** Explore smoothing, sampling, and perplexity calculations from the notebook with guided prompts.
+- **Evaluation reflection (15 min):** Discuss why models fail, compare perplexity scores, and plan improvements.
+
+## Warm-Up Game: "Next Word?"
+1. Present partial sentences like "The dragon breathed ___" or "In a galaxy far, far ___".
+2. Have students write predictions on sticky notes; reveal actual endings.
+3. Introduce the concept of **context length**—some endings are obvious with two previous words, others remain ambiguous.
+4. Vocabulary spotlight:
+   - **N-gram:** A chunk of `N` consecutive tokens.
+   - **Conditional probability:** The likelihood of the next token given previous ones, written `P(next | context)`.
+   - **Add-k smoothing:** Adding a small constant to every count to avoid zero probabilities.
+   - **Cross-entropy:** A score summarizing surprise; lower means better predictions.
+
+## Paper-Based Counting Workshop
+Use the corpus:
+```
+the silver spaceship
+the silver dragon
+```
+1. Tokenize into words (include `<BOS>` for beginning-of-sentence if using it later).
+2. Build tables:
+   - **Unigram:** Count each word independently.
+   - **Bigram:** Record every pair `(context, next)`.
+   - **Trigram:** Track triples using two-word contexts.
+3. Practice computing probabilities:
+   - `P(spaceship | the silver)` = trigram count / bigram count for `the silver`.
+   - Apply add-1 smoothing: add 1 to each trigram count and adjust denominators accordingly.
+4. Challenge: Ask students whether `P(dragon | the silver)` changes more for add-1 smoothing than `P(spaceship | the silver)`. Why?
+
+## Connecting to the Notebook
+When running the provided code:
+- Encourage students to print sections of the count dictionaries to confirm they match the manual tables.
+- Before sampling text, ask the class to predict the first three generated words using trigram probabilities.
+- During perplexity computation, pause to interpret the formula. Use a whiteboard derivation to show that cross-entropy is the average negative log probability.
+
+## Understanding Smoothing Deeply
+Lead a short discussion:
+- Without smoothing, what happens if the model never saw a sequence? (Probability becomes zero, and log probability is undefined.)
+- Demonstrate with numbers: if `P = 0` for one token in a 10-token sentence, perplexity becomes infinite.
+- Show how add-0.1 vs add-1 influences rare vs. common sequences using a simple table. Provide calculators so students can compute sample values by hand.
+
+## Sampling Strategies (Hands-On)
+1. **Temperature scaling worksheet:** Give students a list of probabilities for the next token (e.g., `fire:0.6, frost:0.2, friend:0.2`). Ask them to apply temperature 0.5 and 1.5 using the formula `p_i^(1/T) / Σ p_j^(1/T)`. Provide step-by-step hints.
+2. **Dice simulation:** Use a 10-sided die to sample from a probability table rounded to tenths. Students physically roll to generate a sentence fragment.
+3. Compare deterministic "pick the highest" decoding to sampling results. Discuss trade-offs (predictability vs creativity).
+
+## Perplexity as Model Sense-Making
+- Explain perplexity with a metaphor: it measures how many equally likely options the model juggles. A perplexity of 8 means the model feels there are about eight believable next words each time.
+- Have students calculate perplexity for a tiny sentence using provided probabilities. Work through logs step-by-step (offer calculators or precomputed log tables).
+- Ask: does a lower perplexity always mean better text? Discuss cases where the model might memorize and still get low scores.
+
+## Reflection Questions
+- When did the trigram model outperform the bigram model in your experiments? When did it struggle due to sparse data?
+- How did smoothing change the generated stories? Cite specific examples.
+- If you doubled the corpus size, which metric would you expect to improve most—perplexity, vocabulary coverage, or sample diversity?
+
+## Extensions and Challenges
+- **Context showdown:** Have teams build models with different N (2 vs 3 vs 4) and present evidence about which is best on a held-out paragraph.
+- **Error forensics:** Provide a weird generated sentence. Students trace back which probability decisions likely produced it.
+- **Backoff strategy design:** Sketch a pseudocode algorithm for Katz backoff or Kneser-Ney, even if not implemented. Identify when you’d drop from trigram to bigram counts.
+- **Real-world connection:** Research how autocomplete on phones balances N-gram models with neural models. Share findings in a mini-poster.

--- a/slides/L4_Tiny_Transformer_From_Scratch.md
+++ b/slides/L4_Tiny_Transformer_From_Scratch.md
@@ -1,5 +1,70 @@
-# L4 Tiny Transformer From Scratch
+# L4 Tiny Transformer From Scratch — Extended Lesson Notes
 
-- Goal: Implement self-attention and a small Transformer block
-- Hands-on: character-level tiny Transformer trained on theme text
-- Key concept: attention lets tokens look at relevant context
+## Lesson Flow at a Glance
+- **Analogy opener (10 min):** Compare attention to spotlighting key lines in a play script.
+- **Component teardown (25 min):** Walk through Queries, Keys, Values, masking, and positional encodings using manipulatives.
+- **Notebook construction (30 min):** Students implement the attention head, block, and training loop, verifying each piece.
+- **Insight circle (15 min):** Reflect on sample outputs, diagnose errors, and brainstorm architectural tweaks.
+
+## Warm-Up: Spotlight Metaphor
+1. Display a short dialogue. Ask students to highlight which earlier lines help predict the next line.
+2. Introduce self-attention: every token shines a spotlight backward to decide which earlier tokens matter most.
+3. Vocabulary spotlight:
+   - **Self-attention:** Computes how much each token should attend to others.
+   - **Masking:** Prevents peeking into the future.
+   - **Residual connection:** Allows information to flow unchanged around a block.
+   - **Layer normalization:** Stabilizes activations by normalizing features.
+   - **Positional encoding:** Adds order clues.
+
+## Hands-On Attention Mechanics
+Use index cards and string to simulate an attention head.
+1. Assign each student a token from a short sentence and give them three cards labeled Q, K, V with sample numeric values (e.g., small 2D vectors).
+2. Have them compute dot products using calculators or dot-product grids; scale by `1/√d`.
+3. Apply softmax using approximate values (provide a table for `exp(x)` of small numbers). Students convert scores into attention weights that sum to 1.
+4. Each "Value" student multiplies their vector by the attention weight and adds results to produce the final representation for the querying token.
+5. Discuss: Which token ended up contributing most? Does that match intuition?
+
+## Masking Demonstration
+- Use a paper matrix to show how future positions are set to `-∞` before softmax. Cover the upper-right triangle with sticky notes labeled "mask".
+- Ask why this matters when generating text—connect to not cheating on a test.
+
+## Positional Encoding Intuition
+- Draw sine and cosine waves on graph paper. Mark how each position has a unique pair of sine/cos values.
+- Explain that these signals let the model distinguish "dog bites man" from "man bites dog" even if the same words are present.
+- Encourage students to compute the first two positional encoding values for positions 0–5 using a calculator to see the pattern.
+
+## Notebook Guidance
+As learners implement the code:
+1. **Attention head:** Verify shapes at each step. Encourage print statements after matmul operations to confirm dimensions match expectations.
+2. **Multi-head assembly:** Explain how concatenating heads increases the model’s ability to look at different relationship types simultaneously.
+3. **Feedforward network:** Relate it to a tiny MLP applied to each position. Emphasize the role of non-linearity (e.g., GELU/ReLU).
+4. **Training loop:** Connect cross-entropy loss back to Lesson 3’s perplexity. Remind students to monitor loss over epochs.
+5. **Sampling:** Let them try different start prompts and share the funniest outputs.
+
+## Pen-and-Paper Diagnostics
+Provide scenarios and ask students to predict effects before coding:
+- **What if layer norm is removed?** (Training may diverge.)
+- **What if we forget to mask?** (Model sees future tokens and cheat-predicts.)
+- **What if positional encodings are all zeros?** (Model can’t differentiate order.)
+Have them justify answers referencing the attention pipeline.
+
+## Error Debugging Checklist
+- Check tensor shapes—draw a table of expected shapes after each operation.
+- Inspect gradients for NaNs; explain how exploding values may require gradient clipping.
+- Encourage logging sample predictions every few hundred steps to catch degenerate outputs early.
+
+## Extension Activities
+- **Architecture tweaks:** Increase number of heads or layers. Chart loss vs. parameter count on graph paper.
+- **Dropout experiment:** Add dropout to attention weights and feedforward layers. Observe how it affects overfitting on small corpora.
+- **Embedding sharing:** Compare performance when input and output embeddings are tied vs. separate. Discuss parameter efficiency.
+- **Positional creativity:** Try learnable positional embeddings and debate pros/cons vs sinusoidal ones.
+
+## Reflection Prompts
+- Which component felt most magical once you saw it work? Why?
+- How does self-attention generalize the N-gram idea from Lesson 3?
+- If you doubled the block size, what new patterns could the model capture? What costs would that introduce?
+
+## Exit Ticket Options
+- Sketch the flow of data through one Transformer block in five labeled steps.
+- Define "self-attention" in your own words plus an analogy.
+- List two signs (quantitative or qualitative) that training is going well.

--- a/slides/L5_Finetune_with_HuggingFace.md
+++ b/slides/L5_Finetune_with_HuggingFace.md
@@ -1,5 +1,61 @@
-# L5 Finetune with HuggingFace
+# L5 Fine-tune with Hugging Face — Extended Lesson Notes
 
-- Goal: Use a pretrained small GPT and fine-tune on custom corpus
-- Hands-on: load tokenizer/model, prepare dataset, train a few steps
-- Key concept: transfer learning + safety considerations
+## Lesson Flow at a Glance
+- **Bridge from scratch builds (10 min):** Review how Lessons 1–4 prepared us to understand pretrained models.
+- **Workflow storyboard (20 min):** Map the fine-tuning pipeline on a whiteboard before touching code.
+- **Trainer deep dive (30 min):** Execute the notebook while pausing to inspect datasets, tokenization, and training arguments.
+- **Quality checks + ethics (20 min):** Evaluate generated samples, discuss overfitting, and consider responsible deployment.
+
+## Warm-Up Discussion: Why Pretrain?
+1. Ask: "If our tiny Transformer already writes stories, why use Hugging Face models?" Collect hypotheses.
+2. Introduce key terms with quick definitions:
+   - **Pretrained checkpoint:** A model already trained on massive text corpora.
+   - **Fine-tuning:** Nudging weights so outputs match a new domain.
+   - **Overfitting:** When the model memorizes training examples and stops generalizing.
+   - **Learning rate:** Step size for weight updates.
+3. Compare this process to transferring a skilled musician to a new song—lessons 1–4 built the instrument, now we learn a new tune.
+
+## Workflow Storyboard (Pen & Paper)
+Have students sketch a flowchart with boxes for:
+1. **Load tokenizer** → 2. **Prepare dataset** → 3. **Initialize model** → 4. **Set training arguments** → 5. **Run Trainer** → 6. **Evaluate & save**.
+Encourage them to annotate each box with what could go wrong (e.g., dataset too small, learning rate too high). This paper artifact acts as a checklist while coding.
+
+## Notebook Guidance
+As you guide the class through the notebook:
+1. **Tokenizer choices:** Show how to reuse the pretrained tokenizer vs. plugging in a custom BPE vocabulary. Discuss trade-offs (compatibility vs specialization).
+2. **Dataset construction:** Examine a single batch to ensure `input_ids` and `attention_mask` look correct. Have students compute the average sequence length and consider truncation effects.
+3. **Training arguments:** Explain each key hyperparameter. Provide a table for students to note default vs. chosen values and predicted impacts.
+4. **Launching training:** Encourage monitoring the loss curve printed by the Trainer. Ask learners to annotate their storyboard with the observed trend.
+5. **Generation comparison:** After fine-tuning, generate text from the base model and the fine-tuned model. Students highlight stylistic differences using color coding.
+
+## Pen-and-Paper Hyperparameter Lab
+Set up scenario cards describing different goals:
+- "I have only 10 minutes—what should my batch size and epochs be?"
+- "My model overfits quickly—what adjustments help?"
+- "Outputs are bland—how might temperature or top-k sampling change that?"
+Students discuss in small groups and write recommendations referencing the hyperparameters table.
+
+## Monitoring for Overfitting
+- Teach students to compare training loss vs. evaluation loss curves. Provide graph paper for sketching the trends they observe.
+- Introduce simple heuristics: if validation loss plateaus or rises while training loss keeps dropping, consider early stopping.
+- Encourage maintaining a sample journal—after each epoch, paste generated text and note improvements or regressions.
+
+## Responsible Deployment Checkpoints
+1. **Content review:** Reuse Lesson 6 safety ideas to filter outputs for disallowed content.
+2. **Data privacy:** Discuss whether any personal data in the corpus needs anonymization.
+3. **Attribution:** If using fan fiction or internet text, clarify permission and citation expectations.
+4. **Bias audit:** Brainstorm prompts to test for stereotypes. Record findings and mitigation strategies.
+
+## Offline / No-Internet Fallback
+- Revisit the Lesson 4 Transformer. Have students experiment with continuing training on fresh text and compare to the pretrained model’s behavior once they regain connectivity.
+- Encourage saving checkpoints locally and documenting training settings so experiments are reproducible.
+
+## Reflection Prompts
+- Which part of the fine-tuning pipeline felt most sensitive to your choices? Why?
+- How would you explain the benefit of starting from a pretrained model to someone who has only seen Lesson 4’s scratch model?
+- What ethical guardrails would you put in place before sharing your fine-tuned model online?
+
+## Extension Ideas
+- **Hyperparameter sweep journal:** Vary one setting at a time (learning rate, batch size) and capture results in a table.
+- **Dataset curation project:** Design a themed corpus (e.g., eco-fiction) and document cleaning steps.
+- **Model card draft:** Have students write a short model card summarizing intended use, training data, evaluation, and limitations.

--- a/slides/L6_Evaluation_Prompting_Safety.md
+++ b/slides/L6_Evaluation_Prompting_Safety.md
@@ -1,5 +1,58 @@
-# L6 Evaluation Prompting Safety
+# L6 Evaluation, Prompting, and Safety — Extended Lesson Notes
 
-- Goal: Evaluate (perplexity), prompt design, basic guardrails
-- Hands-on: compute perplexity, simple safety filter, prompt tweaks
-- Key concept: measure + iterate responsibly
+## Lesson Flow at a Glance
+- **Metric mindset (10 min):** Review cross-entropy and introduce perplexity with tangible analogies.
+- **Evaluation lab (25 min):** Run perplexity calculations on multiple models using the notebook and compare results.
+- **Prompt engineering studio (20 min):** Craft and test prompt templates; analyze how structure changes responses.
+- **Safety sprint (25 min):** Design simple guardrails, test edge cases, and discuss limitations.
+
+## Warm-Up: Guessing Game for Perplexity
+1. Present a jar with 6 equally likely mystery outcomes vs. a jar with 20 options. Ask: which jar is more "perplexing"?
+2. Connect to perplexity—lower perplexity means fewer believable options.
+3. Vocabulary spotlight:
+   - **Perplexity:** `exp(cross_entropy)`, roughly the number of likely next tokens.
+   - **Held-out set:** Data reserved strictly for evaluation.
+   - **Prompt template:** A reusable structure guiding an LLM’s behavior.
+   - **Guardrail:** Rules or classifiers that prevent unwanted content.
+
+## Evaluation Lab
+### Pen-and-Paper Prep
+- Provide a short token sequence with predicted probabilities from two models (Model A and B).
+- Have students compute cross-entropy manually (using provided `log` values) and then exponentiate to get perplexity.
+- Discuss which model performs better and why small probability differences can impact the final metric.
+
+### Notebook Application
+1. Evaluate the trigram model from Lesson 3 and the tiny Transformer from Lesson 4 on the same held-out paragraph.
+2. Plot or tabulate the perplexities side by side. Encourage students to hypothesize reasons for differences (context length, parameter count, training data).
+3. Challenge: change the held-out text (e.g., swap themes) and observe how perplexity shifts. Does a space-themed model struggle with animal stories?
+
+## Prompt Engineering Studio
+1. Introduce the structured prompt formula: **Role → Task → Constraints → Examples → Check.**
+2. Divide students into teams. Each team creates two prompts for the same task (e.g., "Explain orbital mechanics to a fifth grader").
+3. Use the notebook (or an accessible LLM) to test both prompts. Students annotate responses for clarity, accuracy, and tone.
+4. Pen-and-paper follow-up: Have teams map which prompt elements (examples, constraints) seemed most influential. Encourage them to draw arrows linking prompt components to observed behavior.
+
+## Safety Sprint
+### Designing Rule-Based Filters
+- Brainstorm categories of unsafe or off-mission content relevant to the class (e.g., personal data requests, hate speech, spoilers).
+- On paper, draft simple keyword or pattern rules. Discuss potential false positives/negatives.
+- Implement chosen rules in the notebook’s safety filter and log which ones trigger during tests.
+
+### Stress Testing
+- Provide scripted test prompts, including borderline cases, for students to classify as "allow" or "block" before running through the filter.
+- Compare human predictions with filter outcomes. Where did the filter miss? How might you improve it (add synonyms, use embeddings)?
+
+## Reflection and Ethics Circle
+- How do evaluation metrics and safety checks work together when deploying a model?
+- Share stories of when a prompt tweak drastically improved an answer—what changed?
+- Discuss the limits of rule-based safety: what nuanced cases require human judgment or more advanced classifiers?
+
+## Extension Ideas
+- **Metric mashup:** Combine perplexity with qualitative scoring (human ratings) and debate how to weigh them.
+- **Prompt tournament:** Run brackets where prompts compete on effectiveness. Use a rubric for judging.
+- **Safety roadmap:** Create a poster outlining a multi-layer defense (filters, classifiers, human review) for a hypothetical chatbot.
+
+## Exit Ticket Options
+- Compute perplexity for a two-token toy example given probabilities and explain what the number means.
+- Outline one improvement you would make to the safety filter and why.
+- Write a short paragraph comparing the goals of prompting vs. safety in responsible AI deployment.


### PR DESCRIPTION
## Summary
- expand each slide deck outline into extended lesson notes aligned with the corresponding notebooks
- add hands-on pen-and-paper activities, discussion prompts, and extension ideas for deeper exploration

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9d150aa68832dacc9077b16d6b0be