### PR TITLE
Improve postCreate diagnostics and document devcontainer usage

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+echo "[postCreate] Starting environment setup for llm-course"
+
 # Ensure we can find locally installed user binaries (Codespaces does not add
 # ~/.local/bin to PATH by default during provisioning)
 export PATH="${HOME}/.local/bin:${PATH}"
+echo "[postCreate] PATH updated to include ${HOME}/.local/bin"
 
 # Ensure uv is installed for the current user
 if ! command -v uv >/dev/null 2>&1; then
+  echo "[postCreate] uv not found; installing via official installer"
   mkdir -p "${HOME}/.local/bin"
   curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --yes
+else
+  echo "[postCreate] uv already installed at $(command -v uv)"
 fi
 
+echo "[postCreate] Resolving Python environment with uv sync"
 # Sync the project dependencies into the managed virtual environment (creates
 # .venv/ when missing)
 uv sync --frozen
 
+echo "[postCreate] Registering the managed virtualenv as a Jupyter kernel"
 # Register the project virtual environment as a Jupyter kernel for notebooks
 uv run python -m ipykernel install --user --name llm-course --display-name "Python (.venv)"
+
+echo "[postCreate] Completed environment setup"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ All dependencies are managed with [uv](https://github.com/astral-sh/uv), which w
    - **Linux/macOS**: `source .venv/bin/activate`
    - **Windows (PowerShell)**: `.venv\Scripts\Activate.ps1`
 
+## VS Code Dev Container setup
+If you use GitHub Codespaces or the VS Code **Dev Containers** extension, this repository already includes a ready-to-go configuration under `.devcontainer/`.
+
+1. **Open the folder in a container** using the VS Code command palette (`Dev Containers: Reopen in Container`) or by creating a new Codespace.
+2. During the first create/rebuild cycle the `postCreate.sh` script runs automatically. It:
+   - Adds `~/.local/bin` to `PATH` so the freshly installed tools are discoverable.
+   - Installs `uv` for the current user (skipped when it is already present).
+   - Runs `uv sync --frozen` to materialize `.venv/` with the locked dependencies.
+   - Registers the managed virtual environment as the `Python (.venv)` Jupyter kernel.
+
+You can confirm the script ran by checking the Dev Containers log or by re-running it manually from the workspace root:
+
+```bash
+bash .devcontainer/postCreate.sh
+```
+
+The command is idempotent and safe to run again if you need to refresh the environment.
+
 ## Running
 Launch Jupyter directly through uv so the correct interpreter is used:
 ```bash


### PR DESCRIPTION
## Summary
- add progress logging to the postCreate script to make devcontainer provisioning easier to debug
- document the included devcontainer configuration and how to rerun the setup script manually

## Testing
- bash .devcontainer/postCreate.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9e28ebe5c832dafb609c3677f50ff